### PR TITLE
Support SSH Agent authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,4 +82,7 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 )
 
-replace github.com/aucloud/go-runcmd => github.com/dnachev/go-runcmd v0.0.0-20220711045310-e32641aefa4c
+replace (
+  github.com/aucloud/go-runcmd => github.com/dnachev/go-runcmd v0.0.0-20220712061459-9ce06155c453
+  github.com/aucloud/go-swarm => github.com/dnachev/go-swarm v0.0.0-20220712064632-2085d756edfd
+)

--- a/go.mod
+++ b/go.mod
@@ -81,3 +81,5 @@ require (
 	google.golang.org/grpc v1.42.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )
+
+replace github.com/aucloud/go-runcmd => github.com/dnachev/go-runcmd v0.0.0-20220711045310-e32641aefa4c

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aucloud/go-runcmd v0.0.0-20220111143825-aaec1329e918 h1:YkcdU1Y5xmWMYMf0vYfYH4IuHd+Qqc67gLARAoo3w2Y=
-github.com/aucloud/go-runcmd v0.0.0-20220111143825-aaec1329e918/go.mod h1:KL5Bo1YSYBcaGjUQ0ZpJSDFz1mhWdW9f4m6o7zHf3ks=
 github.com/aucloud/go-sshutil v0.0.0-20220111080955-99a36586cfcc h1:kMROD9X1fenUUBCJcZb0Pa+teeHuNeOyudOT1kR4PTk=
 github.com/aucloud/go-sshutil v0.0.0-20220111080955-99a36586cfcc/go.mod h1:P/60DRwH4lfsyyuygIT4UWFcgtVFxXghTUYurcelte8=
 github.com/aucloud/go-swarm v0.0.0-20220315114454-382fc6f83fd1 h1:4xx1H9yhsDMgyD6qAH/iX3izAi5nuvzajdlLOmehxZc=
@@ -115,6 +113,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dnachev/go-runcmd v0.0.0-20220711045310-e32641aefa4c h1:ICWrFdfctxZaFdcwGKatdQeRWmXXtsds6SoM0UEGPzo=
+github.com/dnachev/go-runcmd v0.0.0-20220711045310-e32641aefa4c/go.mod h1:KL5Bo1YSYBcaGjUQ0ZpJSDFz1mhWdW9f4m6o7zHf3ks=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -437,8 +437,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 h1:0es+/5331RGQPcXlMfP+WrnIIS6dNnNRe0WB02W0F4M=
-golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220314234724-5d542ad81a58 h1:L8CkJyVoa0/NslN3RUMLgasK5+KatNvyRGQ9QyCYAfc=
 golang.org/x/crypto v0.0.0-20220314234724-5d542ad81a58/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -599,8 +597,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220111092808-5a964db01320 h1:0jf+tOCoZ3LyutmCOWpVni1chK4VfFLhRsDK7MhqGRY=
-golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aucloud/go-sshutil v0.0.0-20220111080955-99a36586cfcc h1:kMROD9X1fenUUBCJcZb0Pa+teeHuNeOyudOT1kR4PTk=
 github.com/aucloud/go-sshutil v0.0.0-20220111080955-99a36586cfcc/go.mod h1:P/60DRwH4lfsyyuygIT4UWFcgtVFxXghTUYurcelte8=
-github.com/aucloud/go-swarm v0.0.0-20220315114454-382fc6f83fd1 h1:4xx1H9yhsDMgyD6qAH/iX3izAi5nuvzajdlLOmehxZc=
-github.com/aucloud/go-swarm v0.0.0-20220315114454-382fc6f83fd1/go.mod h1:EIeFtt0wS0ONyO9Y1KzU5OtTAks90+A2XRtO/UgopHU=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.25.3 h1:uM16hIw9BotjZKMZlX05SN2EFtaWfi/NonPKIARiBLQ=
 github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -113,8 +111,10 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dnachev/go-runcmd v0.0.0-20220711045310-e32641aefa4c h1:ICWrFdfctxZaFdcwGKatdQeRWmXXtsds6SoM0UEGPzo=
-github.com/dnachev/go-runcmd v0.0.0-20220711045310-e32641aefa4c/go.mod h1:KL5Bo1YSYBcaGjUQ0ZpJSDFz1mhWdW9f4m6o7zHf3ks=
+github.com/dnachev/go-runcmd v0.0.0-20220712061459-9ce06155c453 h1:5ncG0pEDNxWBO6s0u6QOTu3e9b9Kn/BA7zkOA8ClI7o=
+github.com/dnachev/go-runcmd v0.0.0-20220712061459-9ce06155c453/go.mod h1:KL5Bo1YSYBcaGjUQ0ZpJSDFz1mhWdW9f4m6o7zHf3ks=
+github.com/dnachev/go-swarm v0.0.0-20220712064632-2085d756edfd h1:yzLXIfGbGNsNnZyy2VLeY1rYv0ITFTdy/jwGvUueY84=
+github.com/dnachev/go-swarm v0.0.0-20220712064632-2085d756edfd/go.mod h1:NDwUbpw/it7PxS066Kld/Yp3YLL+BpcWpCr/w6BoWf0=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
This PR depends on:
- [ ] https://github.com/aucloud/go-runcmd/pull/4
- [ ] https://github.com/aucloud/go-swarm/pull/8

It adds a new `bool` property to the provider schema `use_ssh_agent`, which changes the provider to use SSH agent (duh! 😄 ). Notably, this is not supported together with a bastion host.